### PR TITLE
Adding ChefSpec matchers for plist_file LWRP

### DIFF
--- a/vendor/cookbooks/plist/libraries/matchers.rb
+++ b/vendor/cookbooks/plist/libraries/matchers.rb
@@ -1,0 +1,14 @@
+# plist/libraries/matchers.rb
+
+if defined?(ChefSpec)
+  ChefSpec.define_matcher(:plist_file)
+
+  def create_plist_file(resource)
+    ChefSpec::Matchers::ResourceMatcher.new(:plist_file, :create, resource)
+  end
+
+  def update_plist_file(resource)
+    ChefSpec::Matchers::ResourceMatcher.new(:plist_file, :update, resource)
+  end
+
+end


### PR DESCRIPTION
This is a ChefSpec matcher which is usually used by another cookbook dependent on this one for an LWRP to test that LWRP without stepping into this cookbook's actual LWRP code.
The purpose is so unit tests really are only testing the "unit" of code (the cookbook) that they reside in.  While integration tests can test the actual result of the cookbook when run on a test virtual machine.
This is so other cookbooks can simply test that they define a `plist_file` with some state, and then ChefSpec can match against that defined resource & action.  So, as long as the unit tests within this cookbook work to test & actually step into the LWRP to exercise it's code, then other cookbooks can just simply trust this one to self test and perform its responsibility appropriately.

For example, a cookbook might define & test it's usage of `plist_file` like this:

`example_cookbook/recipes/edit_plist.rb`:

``` ruby
example_plist_file = Pathname.new("#{node['etc']['passwd'][node['current_user']]}/Library/Preferences/plist_file_example.plist")

plist_file example_plist_file.basename do
  file example_plist_file
  push "test1", "a", 1
  push "test1", "b", {:c => 'foo'}
  owner node['current_user']
  mode "0600"
  action :update
end
```

`spec/spec_helper.rb`: 

``` ruby
require 'chefspec'
require 'chefspec/berkshelf'

## Gets rid of const redefinition warnings
def create_singleton_struct name, fields
  if Struct::const_defined? name
    Struct.const_get name
  else
    Struct.new name, *fields
  end
end

at_exit { ChefSpec::Coverage.report! }
```

`example_cookbook/spec/unit/recipes/edit_plist_spec.rb`:

``` ruby
require 'spec_helper'

describe "example_cookbook::edit_plist" do
  let(:chef_run) {
    klass = ChefSpec.constants.include?(:SoloRunner) ? ChefSpec::SoloRunner : ChefSpec::Runner
    klass.new do |node|
      create_singleton_struct "EtcPasswd", [ :name, :passwd, :uid, :gid, :gecos, :dir, :shell, :change, :uclass, :expire ]
      node.set['etc']['passwd']['brubble'] = Struct::EtcPasswd.new('brubble', '********', 501, 20, 'Barney Rubble', '/Users/brubble', '/bin/bash', 0, '', 0)
      node.set['current_user'] = 'brubble'
    end.converge(described_recipe)
  }

  it "updates info into plist file" do
    expect(chef_run).to update_plist_file('plist_file_example.plist')
  end
end
```
